### PR TITLE
New minimum required PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "symfony/event-dispatcher": "~2.8|~3.0"
     },
     "require-dev": {
-        "phake/phake": "~2.3",
-        "phpunit/phpunit": "~5.6"
+        "phpunit/phpunit": "~6.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Event/EventCollection.php
+++ b/src/Event/EventCollection.php
@@ -30,17 +30,11 @@ class EventCollection
         $this->events = $events;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function add(EventInterface $entity)
     {
         $this->events[$entity->getEventId()] = $entity;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function get($key)
     {
         if (array_key_exists($key, $this->events)) {
@@ -50,9 +44,6 @@ class EventCollection
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function remove(EventInterface $entity)
     {
         if (array_key_exists($entity->getEventId(), $this->events)) {
@@ -60,25 +51,16 @@ class EventCollection
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function count()
     {
         return count($this->events);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getIterator()
     {
         return new \ArrayIterator($this->events);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray()
     {
         return $this->events;

--- a/src/State/StateCollection.php
+++ b/src/State/StateCollection.php
@@ -30,17 +30,11 @@ class StateCollection
         $this->states = $states;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function add(StateInterface $entity)
     {
         $this->states[$entity->getStateId()] = $entity;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function get($key)
     {
         if (array_key_exists($key, $this->states)) {
@@ -50,34 +44,22 @@ class StateCollection
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function remove(StateInterface $entity)
     {
         if (array_key_exists($entity->getStateId(), $this->states)) {
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function count()
     {
         return count($this->states);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getIterator()
     {
         return new \ArrayIterator($this->states);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray()
     {
         return $this->states;

--- a/tests/State/InitialStateTest.php
+++ b/tests/State/InitialStateTest.php
@@ -12,12 +12,13 @@
 
 namespace Stagehand\FSM\State;
 
+use PHPUnit\Framework\TestCase;
 use Stagehand\FSM\Event\TransitionEvent;
 
 /**
  * @since Class available since Release 2.1.0
  */
-class InitialStateTest extends \PHPUnit_Framework_TestCase
+class InitialStateTest extends TestCase
 {
     /**
      * @test
@@ -31,6 +32,8 @@ class InitialStateTest extends \PHPUnit_Framework_TestCase
         try {
             $state->addTransitionEvent(new TransitionEvent('foo'));
         } catch (InvalidEventException $e) {
+            $this->assertTrue(true);
+
             return;
         }
 

--- a/tests/State/StateTest.php
+++ b/tests/State/StateTest.php
@@ -12,12 +12,13 @@
 
 namespace Stagehand\FSM\State;
 
+use PHPUnit\Framework\TestCase;
 use Stagehand\FSM\Event\TransitionEvent;
 
 /**
  * @since Class available since Release 2.0.0
  */
-class StateTest extends \PHPUnit_Framework_TestCase
+class StateTest extends TestCase
 {
     /**
      * @test
@@ -29,6 +30,8 @@ class StateTest extends \PHPUnit_Framework_TestCase
         try {
             $state->setEntryEvent(new TransitionEvent('bar'));
         } catch (InvalidEventException $e) {
+            $this->assertTrue(true);
+
             return;
         }
 
@@ -45,6 +48,8 @@ class StateTest extends \PHPUnit_Framework_TestCase
         try {
             $state->setExitEvent(new TransitionEvent('bar'));
         } catch (InvalidEventException $e) {
+            $this->assertTrue(true);
+
             return;
         }
 
@@ -61,6 +66,8 @@ class StateTest extends \PHPUnit_Framework_TestCase
         try {
             $state->setDoEvent(new TransitionEvent('bar'));
         } catch (InvalidEventException $e) {
+            $this->assertTrue(true);
+
             return;
         }
 

--- a/tests/StateMachine/StateMachineBuilderTest.php
+++ b/tests/StateMachine/StateMachineBuilderTest.php
@@ -12,10 +12,12 @@
 
 namespace Stagehand\FSM\StateMachine;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @since Class available since Release 2.0.0
  */
-class StateMachineBuilderTest extends \PHPUnit_Framework_TestCase
+class StateMachineBuilderTest extends TestCase
 {
     /**
      * @test
@@ -62,7 +64,7 @@ class StateMachineBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function setsTheStateMachineObject()
     {
-        $stateMachine1 = \Phake::mock('Stagehand\FSM\StateMachine\StateMachineInterface');
+        $stateMachine1 = new StateMachine();
         $stateMachineBuilder = new StateMachineBuilder($stateMachine1);
         $stateMachine2 = $stateMachineBuilder->getStateMachine();
 

--- a/tests/StateMachine/StateMachineTest.php
+++ b/tests/StateMachine/StateMachineTest.php
@@ -12,8 +12,8 @@
 
 namespace Stagehand\FSM\StateMachine;
 
+use PHPUnit\Framework\TestCase;
 use Stagehand\FSM\Event\EventInterface;
-use Stagehand\FSM\State\State;
 use Stagehand\FSM\State\StateInterface;
 use Stagehand\FSM\StateMachine\StateMachineTest\CallableActionRunner;
 use Stagehand\FSM\StateMachine\StateMachineTest\CallableGuardEvaluator;
@@ -25,7 +25,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * @since Class available since Release 0.1.0
  */
-class StateMachineTest extends \PHPUnit_Framework_TestCase
+class StateMachineTest extends TestCase
 {
     /**
      * @var StateMachineBuilder
@@ -432,6 +432,8 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
         try {
             $stateMachine->triggerEvent('foo');
         } catch (StateMachineNotStartedException $e) {
+            $this->assertTrue(true);
+
             return;
         }
 
@@ -451,6 +453,8 @@ class StateMachineTest extends \PHPUnit_Framework_TestCase
         try {
             $stateMachine->start();
         } catch (StateMachineAlreadyStartedException $e) {
+            $this->assertTrue(true);
+
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | BSD-2-Clause

This will migrate tests to PHPUnit 6.

Phake will be removed since PHPUnit 6 requires `sebastian/comparator` 2.0 or grater.
