### PR TITLE
Add Symfony 5 support. Drop Symfony 2 and Symfony 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
         }
     ],
     "require": {
-        "php": ">=7.0.8",
-        "symfony/event-dispatcher": "~2.8|~3.0|~4.0"
+        "symfony/event-dispatcher-contracts": "^1.0|^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.5"
+        "phpunit/phpunit": "~6.5",
+        "symfony/event-dispatcher": "^4.4|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~6.5",
-        "symfony/event-dispatcher": "^4.4|^5.0"
+        "symfony/event-dispatcher": "^4.3|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/StateMachine/StateMachine.php
+++ b/src/StateMachine/StateMachine.php
@@ -22,7 +22,7 @@ use Stagehand\FSM\State\TransitionalStateInterface;
 use Stagehand\FSM\Transition\ActionRunnerInterface;
 use Stagehand\FSM\Transition\GuardEvaluatorInterface;
 use Stagehand\FSM\Transition\TransitionInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @see  http://en.wikipedia.org/wiki/Finite_state_machine
@@ -195,7 +195,7 @@ class StateMachine implements StateMachineInterface
             $event = $this->currentState->getTransitionEvent(array_shift($this->eventQueue));
             if ($event !== null) {
                 if ($this->eventDispatcher !== null) {
-                    $this->eventDispatcher->dispatch(StateMachineEvents::EVENT_PROCESS, new StateMachineEvent($this, $this->currentState, $event));
+                    $this->eventDispatcher->dispatch(new StateMachineEvent($this, $this->currentState, $event), StateMachineEvents::EVENT_PROCESS);
                 }
 
                 $fromState = $this->currentState;
@@ -211,7 +211,7 @@ class StateMachine implements StateMachineInterface
                 $doEvent = $this->currentState->getDoEvent();
                 if ($doEvent !== null) {
                     if ($this->eventDispatcher !== null) {
-                        $this->eventDispatcher->dispatch(StateMachineEvents::EVENT_DO, new StateMachineEvent($this, $this->currentState, $doEvent));
+                        $this->eventDispatcher->dispatch(new StateMachineEvent($this, $this->currentState, $doEvent), StateMachineEvents::EVENT_DO);
                     }
 
                     $this->runAction($this, $doEvent);
@@ -380,7 +380,7 @@ class StateMachine implements StateMachineInterface
             $exitEvent = $transition->getFromState()->getExitEvent();
             if ($exitEvent !== null) {
                 if ($this->eventDispatcher !== null) {
-                    $this->eventDispatcher->dispatch(StateMachineEvents::EVENT_EXIT, new StateMachineEvent($this, $transition->getFromState(), $exitEvent));
+                    $this->eventDispatcher->dispatch(new StateMachineEvent($this, $transition->getFromState(), $exitEvent), StateMachineEvents::EVENT_EXIT);
                 }
 
                 $this->runAction($this, $exitEvent);
@@ -388,7 +388,7 @@ class StateMachine implements StateMachineInterface
         }
 
         if ($this->eventDispatcher !== null) {
-            $this->eventDispatcher->dispatch(StateMachineEvents::EVENT_TRANSITION, new StateMachineEvent($this, null, $transition->getEvent(), $transition));
+            $this->eventDispatcher->dispatch(new StateMachineEvent($this, null, $transition->getEvent(), $transition), StateMachineEvents::EVENT_TRANSITION);
         }
         $this->runAction($this, $transition->getEvent(), $transition);
         $this->previousState = $transition->getFromState();
@@ -399,7 +399,7 @@ class StateMachine implements StateMachineInterface
             $entryEvent = $toState->getEntryEvent();
             if ($entryEvent !== null) {
                 if ($this->eventDispatcher !== null) {
-                    $this->eventDispatcher->dispatch(StateMachineEvents::EVENT_ENTRY, new StateMachineEvent($this, $toState, $entryEvent));
+                    $this->eventDispatcher->dispatch(new StateMachineEvent($this, $toState, $entryEvent), StateMachineEvents::EVENT_ENTRY);
                 }
 
                 $this->runAction($this, $entryEvent);

--- a/src/StateMachine/StateMachineEvent.php
+++ b/src/StateMachine/StateMachineEvent.php
@@ -15,7 +15,7 @@ namespace Stagehand\FSM\StateMachine;
 use Stagehand\FSM\Event\EventInterface;
 use Stagehand\FSM\State\StateInterface;
 use Stagehand\FSM\Transition\TransitionInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @since Class available since Release 2.1.0

--- a/tests/StateMachine/StateMachineTest.php
+++ b/tests/StateMachine/StateMachineTest.php
@@ -19,7 +19,7 @@ use Stagehand\FSM\Transition\ActionRunnerInterface;
 use Stagehand\FSM\Transition\GuardEvaluatorInterface;
 use Stagehand\FSM\Transition\TransitionInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @since Class available since Release 0.1.0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | BSD-2-Clause

Use `symfony/event-dispatcher-contracts` instead of concrete implementation. This adds support for symfony 5.x versions and drops support for versions below 4.3. Since contract was implemented only in 4.3.0
